### PR TITLE
(feature) Document how to use GitHub PR review tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ decisions.
    people agree rejecting it is the right thing to do. In this case the PR
    should be closed with a suitable comment.
 
+## Voting with the GitHub review system
+
+Given that there are a number of
+[tools available to us when using Pull Requests](https://help.github.com/en/articles/about-pull-request-reviews)
+to facilitate this process we should be explicit about how we use each to
+communicate in order that it is clear how we can reach consensus.
+
+### Comment
+
+- Not indicative of preference and can be used for any questions, suggestions
+and typos
+
+### Approve
+
+- This decision SHOULD be accepted
+- A description is optional
+
+### Request changes
+
+- This decision SHOULD NOT be accepted unless the given consequences are
+acceptable
+- A description is required and please be prepared to respond to further
+comments
+
+### Emoji/reactions
+
+- Not indicative of preference
+
 ## Linting
 
 First install dependencies:


### PR DESCRIPTION
* As the documentation describes this attempts to make it clear how we can conclude wether a decision has consensus or not.
* GitHub settings currently have a minimum of 3 approvals required. Using this as our source of approval rather than :thumbs-up: emojis will offer a single source of truth for consensus. In the same way request for changes over :thumbs-down: will be more helpful as it gives the person a natural place to leave comment beside their opinion.
* Using approvals and request for changes will also serve to document a reversal of decision whereas it will be impossible to track the movement in emojis as a decision is ammended.