### PR TITLE
Stop using the extended packages for linting on Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,3 @@
 remark:
   enabled: true
-  config_file: .remarkrc
+  config_file: .remarkrc.hound

--- a/.remarkrc.hound
+++ b/.remarkrc.hound
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "listItemIndent": "1",
+    "incrementListMarker": false
+  },
+  "plugins": [
+    "remark-preset-lint-markdown-style-guide",
+    ["remark-lint-list-item-spacing", { "checkBlanks": true }]
+  ]
+}


### PR DESCRIPTION
Hound doesn't appear to install any dependencies, causing errors when linting.