### PR TITLE
Use the "Scripts To Rule Them All" pattern for common tasks

### DIFF
--- a/rfc-023-use-scripts-to-rule-them-all.md
+++ b/rfc-023-use-scripts-to-rule-them-all.md
@@ -41,4 +41,5 @@ necessary configuration and run tests on a continuous integration server.
 
 ## Next steps
 
-- Add `script/bootstrap`, `script/test` and `script/server` to the [rails-template](https://github.com/dxw/rails-template)
+- Add examples of all scripts to the
+- [rails-template](https://github.com/dxw/rails-template).

--- a/rfc-023-use-scripts-to-rule-them-all.md
+++ b/rfc-023-use-scripts-to-rule-them-all.md
@@ -18,9 +18,6 @@ onboarding new developers to a project.
 
 ## Proposal
 
-We SHOULD prefer the patterns in the [Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all)
-repository for tasks which are covered by that pattern.
-
 An application SHOULD have a `script/bootstrap` script which fulfils the
 application's dependencies for the environment it is run in.
 
@@ -30,7 +27,13 @@ suite.
 An application SHOULD have a `script/server` script which will start a working
 instance of the application.
 
-An application MAY have other scripts following the pattern.
+An application MAY have a `script/setup` script.
+
+An application MAY have a `script/update` script.
+
+An application MAY have a `script/console` script.
+
+An application MAY have a `script/cibuild` script.
 
 ## Next steps
 

--- a/rfc-023-use-scripts-to-rule-them-all.md
+++ b/rfc-023-use-scripts-to-rule-them-all.md
@@ -2,9 +2,9 @@
 
 ## Summary
 
-We should adopt the [Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all)
-pattern which GitHub uses to standardise the names of common scripts between
-various applications.
+We should adopt the [Scripts To Rule Them
+All](https://github.com/github/scripts-to-rule-them-all) pattern which GitHub
+uses to standardise the names of common scripts between various applications.
 
 Standardising the names, locations and behaviour of these scripts makes the
 experience of developing, testing and running applications more consistent.
@@ -18,22 +18,26 @@ onboarding new developers to a project.
 
 ## Proposal
 
-An application SHOULD have a `script/bootstrap` script which fulfils the
+An application SHOULD have a `script/bootstrap` script, which fulfils the
 application's dependencies for the environment it is run in.
 
-An application SHOULD have a `script/test` script which runs a standard test
+An application SHOULD have a `script/test` script, which runs a standard test
 suite.
 
-An application SHOULD have a `script/server` script which will start a working
+An application SHOULD have a `script/server` script, which will start a working
 instance of the application.
 
-An application MAY have a `script/setup` script.
+An application MAY have a `script/setup` script, which will bring the
+application to a known state following a clone.
 
-An application MAY have a `script/update` script.
+An application MAY have a `script/update` script, which will perform necessary
+migrations and bootstrapping following an update to the code.
 
-An application MAY have a `script/console` script.
+An application MAY have a `script/console` script, which will open the
+application's console.
 
-An application MAY have a `script/cibuild` script.
+An application MAY have a `script/cibuild` script, which will perform the
+necessary configuration and run tests on a continuous integration server.
 
 ## Next steps
 

--- a/rfc-023-use-scripts-to-rule-them-all.md
+++ b/rfc-023-use-scripts-to-rule-them-all.md
@@ -1,0 +1,37 @@
+# Use the "Scripts To Rule Them All" pattern for common tasks
+
+## Summary
+
+We should adopt the [Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all)
+pattern which GitHub uses to standardise the names of common scripts between
+various applications.
+
+Standardising the names, locations and behaviour of these scripts makes the
+experience of developing, testing and running applications more consistent.
+
+## Problem
+
+Applications currently perform a number of common tasks in different ways. The
+exact way a task is conventionally performed for an application isn't always
+documented, or is not documented consistently. This increases friction for
+onboarding new developers to a project.
+
+## Proposal
+
+We SHOULD prefer the patterns in the [Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all)
+repository for tasks which are covered by that pattern.
+
+An application SHOULD have a `script/bootstrap` script which fulfils the
+application's dependencies for the environment it is run in.
+
+An application SHOULD have a `script/test` script which runs a standard test
+suite.
+
+An application SHOULD have a `script/server` script which will start a working
+instance of the application.
+
+An application MAY have other scripts following the pattern.
+
+## Next steps
+
+- Add `script/bootstrap`, `script/test` and `script/server` to the [rails-template](https://github.com/dxw/rails-template)


### PR DESCRIPTION
We should adopt the [Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all) pattern which GitHub uses to standardise the names of common scripts between various applications.

Standardising the names, locations and behaviour of these scripts makes the experience of developing, testing and running applications more consistent.

This RFC encourages the adoption of the pattern, and explicitly states that projects SHOULD have scripts for bootstrapping, testing and starting a server, and MAY have other scripts for tasks such as setup, update, opening a console and running tests in a CI environment.