### PR TITLE
Update existing RFCs to pass automatic linting

### DIFF
--- a/rfc-013-use-docker-to-deploy-and-run-applications-in-containers.md
+++ b/rfc-013-use-docker-to-deploy-and-run-applications-in-containers.md
@@ -95,4 +95,4 @@ MUST be added to the project to explain and document why.
 
 - Add a Dockerfile to the [rails-template](https://github.com/dxw/rails-template)
 - Edit the GitHub action script that runs CI in the [rails-template](https://github.com/dxw/rails-template)
-to build and test with Docker containers
+  to build and test with Docker containers

--- a/rfc-019-use-changelogs-to-track-changes.md
+++ b/rfc-019-use-changelogs-to-track-changes.md
@@ -72,4 +72,5 @@ instructions for how to update it when making contributions and releasing
 projects built from it, and a prompt in the pull request template.
 
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/
+
 [rails-template]: https://github.com/dxw/rails-template

--- a/rfc-021-use-auth0-as-the-default-auth-provider.md
+++ b/rfc-021-use-auth0-as-the-default-auth-provider.md
@@ -2,7 +2,8 @@
 
 ## Summary
 
-Use Auth0 as an authentication and authorisation service for Rails projects where clients do not have a preferred choice.
+Use Auth0 as an authentication and authorisation service for Rails projects
+where clients do not have a preferred choice.
 
 ## Problem
 
@@ -10,23 +11,34 @@ Our services regularly need a mechanism for authentication and authorisation.
 
 Where clients do have a preexisting tool or preference this decision is usually
 straight forward as we look to align new services with those that already exist.
-This can help provide users a joined up and consistent journey across all services within an organisation.
+This can help provide users a joined up and consistent journey across all
+services within an organisation.
 
-Where one does not exist and we must choose we have to spend time early on deciding what we should do and this impacts on delivery.
+Where one does not exist and we must choose we have to spend time early on
+deciding what we should do and this impacts on delivery.
 
-Supporting services which each use different auth services is challenging. Each require the whole support team to be set up with accounts. Each service then offers its own user experience to perform the same routine tasks. Where we can we should offer consistency to help with this.
+Supporting services which each use different auth services is challenging. Each
+require the whole support team to be set up with accounts. Each service then
+offers its own user experience to perform the same routine tasks. Where we can
+we should offer consistency to help with this.
 
-We do not want to roll our own authentication code. Doing security well is a complex task that takes a lot of time at set up and in ongoing costs.
+We do not want to roll our own authentication code. Doing security well is a
+complex task that takes a lot of time at set up and in ongoing costs.
 
-The tool we decide on should be open source and offer open and common industry standards. This should improve security and portability for migrating from later.
+The tool we decide on should be open source and offer open and common industry
+standards. This should improve security and portability for migrating from
+later.
 
 ## Proposal
 
-We SHOULD first seek to use existing auth services where clients have them in place.
+We SHOULD first seek to use existing auth services where clients have them in
+place.
 
-When there is not an existing solution, we SHOULD use [Auth0](https://auth0.com) in our Rails projects.
+When there is not an existing solution, we SHOULD use [Auth0](https://auth0.com)
+in our Rails projects.
 
-[Auth0 offers open and common standards](https://auth0.com/docs/protocols) including:
+[Auth0 offers open and common standards](https://auth0.com/docs/protocols)
+including:
 
 - OAuth 2.0
 - OpenID Connect
@@ -34,14 +46,19 @@ When there is not an existing solution, we SHOULD use [Auth0](https://auth0.com)
 - WS-Federation
 - LDAP
 
-Auth0 is a hosted service and not something we have to support. They are responsible for the uptime.
+Auth0 is a hosted service and not something we have to support. They are
+responsible for the uptime.
 
-We MAY use it to create and manage users rather than building support within each service.
+We MAY use it to create and manage users rather than building support within
+each service.
 
 Auth0 offers competitive pricing and forgiving quota allowances.
 
-Auth0 offers an ability to run in proxy mode, this allows forwarding to popular SSO providers such as Okta or Google. This provides us an efficient way to migrate later.
+Auth0 offers an ability to run in proxy mode, this allows forwarding to popular
+SSO providers such as Okta or Google. This provides us an efficient way to
+migrate later.
 
 ## Next steps
 
-As the majority of clients have auth services it does not seem appropriate to add anything to the rails-template.
+As the majority of clients have auth services it does not seem appropriate to
+add anything to the rails-template.


### PR DESCRIPTION
Following the addition of automated linting to commits, this PR brings existing RFCs up to passing standard. There are no content changes.