### PR TITLE
Fix incorrect formatting in RFC 023

### DIFF
--- a/rfc-023-use-scripts-to-rule-them-all.md
+++ b/rfc-023-use-scripts-to-rule-them-all.md
@@ -41,5 +41,5 @@ necessary configuration and run tests on a continuous integration server.
 
 ## Next steps
 
-- Add examples of all scripts to the
-- [rails-template](https://github.com/dxw/rails-template).
+- Add examples of all scripts to the 
+  [rails-template](https://github.com/dxw/rails-template).


### PR DESCRIPTION
Atom did not correctly place a line break during automatic hard breaking.