### PR TITLE
Add `synchronize` option to check-for-new action

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -3,6 +3,7 @@ on:
     types:
       - labeled
       - unlabeled
+      - synchronize
 
 jobs:
   check-for-new:


### PR DESCRIPTION
Without this, it’s impossible to get this action to run again after pushing to the branch without adding/removing a label, meaning the PR can’t be merged, even if all the other prerequisites are met.