### PR TITLE
Remove dependabot checks for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: daily
-    versioning-strategy: increase


### PR DESCRIPTION
renovate is our preferred tooling choice.

https://dxw.slack.com/archives/CD8TQ9NP9/p1684141816581729?thread_ts=1684141413.964359&cid=CD8TQ9NP9