### PR TITLE
renovate PRs will not have 'new' label auto-added

### DIFF
--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -15,4 +15,5 @@ jobs:
         with:
           add-labels: "new"
           ignore-if-assigned: false
+          ignore-if-labeled: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "labels": ["dependencies"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "labels": ["dependencies"]
+  "labels": ["dependencies", "tooling"]
 }


### PR DESCRIPTION
This is so that we can bypass the 14 day wait for new RFC PRS before they can be merged. 

renovate created PRs will have the `dependencies` label automatically added to them. Any PRs that have a label already attached will not be treated as an RFC.