### PR TITLE
Allow different approval counts based on PR type (RFC or Tooling)

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -1,0 +1,54 @@
+name: Check approvals
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+jobs:
+  check-approvals-tooling:
+    name: Tooling
+
+    if: contains(github.event.pull_request.labels.*.name, 'tooling')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo "Approvals required: ${APPROVALS_REQUIRED}"
+
+          gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+            | jq '.[] | "\(.user.login) \(.state)"' \
+            | uniq \
+            | grep -c 'APPROVED' \
+            | xargs test "${APPROVALS_REQUIRED}" -le
+        env:
+          GH_TOKEN: ${{ github.token }}
+          APPROVALS_REQUIRED: 1
+
+  check-approvals-rfcs:
+    name: RFCs
+
+    if: "!contains(github.event.pull_request.labels.*.name, 'tooling')"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo "Approvals required: ${APPROVALS_REQUIRED}"
+
+          gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+            | jq '.[] | "\(.user.login) \(.state)"' \
+            | uniq \
+            | grep -c 'APPROVED' \
+            | xargs test "${APPROVALS_REQUIRED}" -le
+        env:
+          GH_TOKEN: ${{ github.token }}
+          APPROVALS_REQUIRED: 3


### PR DESCRIPTION
## What?

- Add a workflow action for checking PR type and checking number of approvals based on that

## Why?

- So that for RFC PRs we can set required approvals to 3. An RFC PR is any that doesn't have a `tooling` label.
- For tooling related PRs we can set required approvals to 1. A tooling PR is one that has the `tooling` label.

This would resolve #17 . Once merged, we would be able to remove the branch protection setting for number of approvals, and let the workflow handle it instead.

It would look like this in the "Checks" area of a PR:

<img width="510" alt="image" src="https://github.com/dxw/tech-team-rfcs/assets/9681/4b05ee13-76b7-4b80-a2bc-2e20491fe776">

In this example, it's a Tooling PR with no approvals.