### PR TITLE
Clarify linting RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ or TypeScript, which are subcategorised for ease of reference.
 
 - [Use Docker to deploy and run our applications in containers][013]
 - [Use Auth0 as the default auth provider][021]
-- [Use standard linting tools across all of our projects][035]
+- [Use linting tools across all of our projects][035]
 - [Use existing libraries where possible][087]
 
 #### GovPress
@@ -230,7 +230,7 @@ intended it to be.
 [024]: tools-and-technology/rails/rfc-024-use-brakeman.md
 [028]: ways-of-working/rfc-028-adopt-a-code-of-conduct.md
 [029]: ways-of-working/rfc-029-source-code-should-be-open-source-by-default.md
-[035]: tools-and-technology/rfc-035-use-standard-linting-tools-across-all-our-projects.md
+[035]: tools-and-technology/rfc-035-use-linting-tools-across-all-our-projects.md
 [036]: ways-of-working/rfc-036-dont-use-master-as-a-branch-name.md
 [079]: ways-of-working/rfc-079-script-imports-of-production-data.md
 [087]: tools-and-technology/rfc-087-use-libraries-where-possible.md

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ or TypeScript, which are subcategorised for ease of reference.
 - [Use ERB by default in our Rails projects][022]
 - [Use Brakeman on all Rails projects][024]
 
+<!-- markdownlint-disable MD026 -->
+
 ## How it works...
+
+<!-- markdownlint-enable MD001 -->
 
 ### ...for a proposer
 

--- a/tools-and-technology/rfc-035-use-linting-tools-across-all-our-projects.md
+++ b/tools-and-technology/rfc-035-use-linting-tools-across-all-our-projects.md
@@ -1,4 +1,4 @@
-# Use standard linting tools across all of our projects
+# Use linting tools across all of our projects
 
 ## Summary
 
@@ -15,14 +15,20 @@ style in code reviews, which can cause conflict and slow down code review.
 ## Proposal
 
 Where available, all new dxw-owned or maintained repositories SHOULD use an
-opinionated code linter and formatter to make sure code meets a standard style.
-Examples of this include (but are not limited to):
+opinionated code linter and formatter to make sure code meets a consistent
+style. Examples of this include (but are not limited to):
 
-- [Standard.rb](https://github.com/testdouble/standard)
-- [Standard for Javascript](https://github.com/standard/standard)
-- [Standard for Typescript](https://github.com/standard/ts-standard)
-- [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)
-- [Black (for Python)](https://github.com/psf/black)
+- Ruby: [Standard Ruby](https://github.com/testdouble/standard)
+- JavaScript/TypeScript:
+  - ESLint:
+    [JS](https://github.com/eslint/eslint)/[TS](https://github.com/typescript-eslint/typescript-eslint)
+  - [Prettier](https://github.com/prettier/prettier)
+  - Standard:
+    [JS](https://github.com/standard/standard)/[TS](https://github.com/standard/ts-standard)
+- PHP: [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)
+- Python:
+  - [Black](https://github.com/psf/black)
+  - [djLint](https://github.com/Riverside-Healthcare/djLint)
 
 When a linter is installed, each package MUST run a check using the linting tool
 as part of the default CI build. We MUST ensure a CI build fails if the linting


### PR DESCRIPTION
## Changes in this PR

The use of "standard" in the linting RFC has caused some confusion among developers. While the title is `Use standard` not `Use Standard` and later it says `meets a standard` not `meet Standard`, when scanning the RFC it's easy to mistake this for suggesting we use the specific set of linters called Standard (for languages where they exist, i.e. JavaScript/TypeScript and Ruby)

This removes use of the word "standard" except where referencing linters called Standard, and provides examples of other linters that we also use within the JavaScript/TypeScript domain