### PR TITLE
Ensure approval check runs after PR reviews

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -1,16 +1,7 @@
 name: Check approvals
 
 on:
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   pull_request_review:
-    types: [submitted, edited, dismissed]
 
 jobs:
   check-approvals-tooling:


### PR DESCRIPTION
Fixes #239 

Previously the approvals workflows were set up to be triggered by either a `pull_request` or `pull_request_review` trigger. Each time a workflow is run for one of these triggers, it will not be run for the other. This would mean that when a previous action had run and failed (for example) for a `pull_request` trigger, it would remain failed even after a `pull_request_review` action had run and succeeded. That would mean there was an outstanding check failing even if we had the correct number of approvals. The only way to fix it would be to manually re-run that failed job, which is not ideal.

We will now only check for approval counts after a `pull_request_review` trigger - which is the most essential. The repo has been setup now with a minimum of 1 approval, so a PR can't accidentally be merged without one approval. And at that point, for an RFC PR, once that first approval has been submitted, that will then trigger the workflow check, which will then fail as the required 3 approvals won't have been met. With each subsequent approval, the check will run again until 3x approvals are in place.