### PR TITLE
Remove Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily


### PR DESCRIPTION
Dependency updates are now handled by Renovate, including GitHub actions (which are the only ones covered in this Dependabot configuration).