### PR TITLE
Swap renovate config to use internal standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "labels": ["dependencies", "tooling"]
+  "extends": ["github>dxw/renovate-config:internal"],
+  "addLabels": ["tooling"]
 }


### PR DESCRIPTION
We have a new [standard config](https://github.com/dxw/renovate-config) we're trying out for Renovate, so all our internal repos behave the same way.

This also disables dependabot dependency updates, since Renovate handles them.

This config does have a difference from the base one, in that it also adds the `tooling` tag. This means the needed reviews will be reduced from three to one (although Renovate will bypass review for automerging minor updates anyway).