### PR TITLE
Update example pull request link for playwright

### DIFF
--- a/ways-of-working/rfc-244-use-automated-accessibility-checks-in-feature-tests.md
+++ b/ways-of-working/rfc-244-use-automated-accessibility-checks-in-feature-tests.md
@@ -78,7 +78,7 @@ Example pull requests using [cypress-axe][axe-cypress]:
 Example pull requests using [@axe-core/playwright][axe-playwright]:
 
 - [Find information about academies and trusts
-  #34][dfe-find-information-about-academies-and-trusts-34]
+  #150][dfe-find-information-about-academies-and-trusts-150]
 
 ## Next steps
 
@@ -88,7 +88,7 @@ Example pull requests using [@axe-core/playwright][axe-playwright]:
 [axe-coverage-report]: https://www.deque.com/automated-accessibility-testing-coverage
 [axe-cypress]: https://github.com/component-driven/cypress-axe
 [axe-playwright]: https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright
-[dfe-find-information-about-academies-and-trusts-34]: https://github.com/DFE-Digital/find-information-about-academies-and-trusts/pull/34
+[dfe-find-information-about-academies-and-trusts-150]: https://github.com/DFE-Digital/find-information-about-academies-and-trusts/pull/150
 [dxw-accessibility-manual]: https://accessibility.dxw.com
 [dxw-accessibility-principle]: https://playbook.dxw.com/about-us/our-mission-values-and-principles/#make-everything-we-do-accessible
 [dxw-mission-statement]: https://playbook.dxw.com/about-us/our-mission-values-and-principles/#our-mission


### PR DESCRIPTION
This is an update to the 'example pull request' link for setting up accessibility tests in Playwright using the axe-core package.

Have updated with a later PR in the project, as it shows an example set up of a custom assertion using the accessibility scanner, which used in a number of tests.

The original PR linked showed the use of the scanner used in one test, which is not as useful to developers looking to adopt the approach in their tests.

We have included a link to the first PR in this one as a reference.