### PR TITLE
Run check approvals on PR changes

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -1,6 +1,10 @@
 name: Check approvals
 
 on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
   pull_request_review:
 
 jobs:


### PR DESCRIPTION
Tooling PRs should only require one approval, per this action. However, this action would only update the required number of approvals on submission of a new review (I think), meaning that if the 'tooling' label was added after an approving review, the required number of approvals wouldn't be updated and the PR would still be blocked

This sets the action to trigger whenever labels are changed

Example of where this is an issue: #255 